### PR TITLE
Add blog posts from 2025

### DIFF
--- a/blog/posts/20241121-confused-Techie-v1.123.0.md
+++ b/blog/posts/20241121-confused-Techie-v1.123.0.md
@@ -12,7 +12,7 @@ Pulsar [1.123.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.123.0) is
 
 <!-- more -->
 
-## Pulsar Pulsar 1.123.0: Is It Winter Yet?!
+## Pulsar 1.123.0: Is It Winter Yet?!
 
 This time around there's been a big focus on bug fixes and compatibility:
 ensuring Linux users are able to load the new SQL State Storage when starting Pulsar from a self-contained binary, and fixing a regression with Electron 12 compatibility for moving items to the trash.

--- a/blog/posts/20250123-confused-Techie-v1.125.0.md
+++ b/blog/posts/20250123-confused-Techie-v1.125.0.md
@@ -1,0 +1,57 @@
+---
+title: "Pulsar v1.125.0: Happy New Years!"
+author: confused-Techie
+date: 2025-01-23
+category:
+  - dev
+tag:
+  - release
+---
+
+Pulsar [1.125.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.125.0) is available now!
+
+<!-- more -->
+
+## Pulsar v1.125.0: Happy New Years!
+
+The Pulsar team is happy to welcome everyone to the new year on our ~~20~~25th regular release.
+
+We've gone back on our last update's decision to add `source comment` to the `spell-check.grammar` setting by default, as it had a greater performance impact than anticipated. This does mean that by default comments in code are no longer spell-checked — but if you liked the feature, you can add that setting back in! Just re-add `source comment` to the list of scopes under "Settings > Packages > spell-check > Grammars."
+
+We've also restored an internal API that was changed a while back, after we learned the change affected the `project-plus` community package.
+
+We have our usual improvements to the Tree-sitter grammars — such as `language-css`'s parser being updated to the latest, and `language-python` getting improved indentation hinting for some unusual code constructs.
+
+We've fixed an issue that would cause `pulsar` and `ppm` to be removed from the user's PATH on Windows during an upgrade, to ensure the choices you select during installation are respected.
+
+We've also engaged in some maintenance and updates to our CI operations, to ensure we can keep things working on all of our supported platforms.
+
+As always, a huge thank you to our community, contributors, and donations.
+Happy coding, and see you amongst the stars!
+\- The Pulsar Team
+
+---
+
+- The Windows installer no longer removes `pulsar` and `ppm` from your path when you update Pulsar to a newer version.
+- [spell-check] Removed `source comment` from the list of automatically checked scopes because of reports of high CPU usage. This means that Pulsar will no longer automatically perform spell-checking for all code comments in all source files. (If you liked the behavior, you can add it back to the list in the `spell-check.grammars` config setting.)
+- [language-python] Improved indentation hinting in some unusual scenarios like on one-line blocks and after code comments.
+- [language-css] Updated `tree-sitter-css` to latest. Selector handling is now much better when typing incomplete selectors in a brand-new CSS file or at the bottom of an existing file.
+- Restored functionality of [project-plus](https://web.pulsar-edit.dev/packages/project-plus) via exposing previously removed internal APIs.
+
+### Pulsar
+
+- Tree-sitter rolling fixes, 1.125 (or 1.124.1) edition [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1172)
+- Windows: Only remove Pulsar/PPM from PATH during uninstall [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/1183)
+- CI: Retry on timeout when building macOS bins [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1178)
+- Install dependencies for CI documentation job [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1193)
+- Attempt to install dependency on new Ubuntu CI images [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1192)
+- CI: No dpkg shenanigans for package tests workflow [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1188)
+- Expose `dbPromise` in `StateStore` [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/1171)
+
+### pulsar-updater
+
+- Don't prompt to update on non-default release channels [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1185)
+
+### spell-check
+
+- Fixes for a possible patch release [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1173)

--- a/blog/posts/20250305-DeeDeeG-v1.126.0.md
+++ b/blog/posts/20250305-DeeDeeG-v1.126.0.md
@@ -1,0 +1,47 @@
+---
+title: "Pulsar v1.126.0: Still Marching On!"
+author: DeeDeeG
+date: 2025-03-05
+category:
+  - dev
+tag:
+  - release
+---
+
+Pulsar [1.126.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.126.0) is available now!
+
+<!-- more -->
+
+## Pulsar v1.126.0: Still Marching On!
+
+This release may be delayed from our usual, but here it finally is!
+
+_(Enjoy folding your arrays, PHP-ists!)_
+
+As always, a huge thank you to our community, contributors, and donations.
+Happy coding, and see you amongst the stars!
+\- The Pulsar Team
+
+---
+
+- Python 3.12+ compatibility in ppm (installing packages with native C/C++ modules with Python 3.12+ on your system should Just Work™). (Python 3.7 and older no-longer supported for installing Pulsar packages with native C/C++ modules with ppm. Does not affect anything other than installing certain Pulsar packages.)
+- PHP arrays spanning multiple lines are now foldable, as they always should have been.
+- Various dependency updates for ppm.
+- `core.allowWindowTransparency` setting is now hidden from the UI, as it has many limits and can cause unexpected issues, a situation which we inherit from the upstream Electron project. (Power-users who understand the drawbacks and still wish to enable transparency can add it to their user config files manually.)
+
+### Pulsar
+
+- CI: Compile newer Python for Cirrus ARM Linux [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1237)
+- CI: Update Rolling token for Cirrus CI [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1226)
+- ppm: Bump ppm to commit 6981ce79e0efdd9bae1fac9bd1 [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1223)
+- Tree-sitter fixes, 1.126.0 edition [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1207)
+- CI: Specify a `PYTHON` env var on Windows so it doesn't get confused [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1220)
+- CI: Run `apt-get update` before installing Pulsar (for package tests) [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1209)
+- Remove `core.allowWindowTransparency` from the config schema [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1206)
+
+### ppm
+
+- Remove dependency on "request" package [@2colours](https://github.com/pulsar-edit/ppm/pull/149)
+- deps: Bump node-gyp to latest ^10.2.0 for Python 3.12 compat [@DeeDeeG](https://github.com/pulsar-edit/ppm/pull/137)
+- Eliminate trivial underscore [@2colours](https://github.com/pulsar-edit/ppm/pull/147)
+- chore(deps): update dependency express to v4.20.0 [security] [@renovate](https://github.com/pulsar-edit/ppm/pull/142)

--- a/blog/posts/20250326-DeeDeeG-v1.127.0.md
+++ b/blog/posts/20250326-DeeDeeG-v1.127.0.md
@@ -1,0 +1,45 @@
+---
+title: "Pulsar v1.127.0: Marching to the Beat of our own Drum"
+author: DeeDeeG
+date: 2025-03-26
+category:
+  - dev
+tag:
+  - release
+---
+
+Pulsar [1.127.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.127.0) is available now!
+
+<!-- more -->
+
+## Pulsar v1.127.0: Marching to the beat of our Own Drum
+
+Another release to round out this month. Enjoy.
+
+As always, a huge thank you to our community, contributors, and donations.
+Happy coding, and see you amongst the stars!
+\- The Pulsar Team
+
+---
+
+- Added a Jasmine 2-based test runner, migrated core editor tests to use it. Packages bundled into the core editor can migrate their tests to use this as well, over time. The Jasmine 1 test runner remains available.
+- Added `--enable-features=UseOzonePlatform` and `--ozone-platform=wayland` as parameters when running under Wayland on Linux (avoids using xwayland, which causes rendering problems on some systems, especially with NVidia)
+- Many Tree-sitter/parser/grammar improvements.
+  - Updated to `web-tree-sitter` version `0.25.3`.
+  - Fixed a bug preventing folds from updating after code changes in some scenarios.
+  - Better folding behavior in Python.
+  - Better folding and syntax highlighting in Ruby of `case`/`in` statements.
+  - Better syntax highlighting of private members in JavScript.
+  - Better folding of multiline comments in PHP.
+- Updated the `read` dependency in ppm
+
+### Pulsar
+
+- ppm: Update ppm to commit a6f843f0381f64cb5865efc7 [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1252)
+- Tree-sitter rolling fixes, 1.127 edition [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1240)
+- Wayland pulsar script [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/1246)
+- Update jasmine to 2.x [@kiskoza](https://github.com/pulsar-edit/pulsar/pull/990)
+
+### ppm
+
+- Update to read v3 [@2colours](https://github.com/pulsar-edit/ppm/pull/150)

--- a/blog/posts/20250329-DeeDeeG-v1.127.1.md
+++ b/blog/posts/20250329-DeeDeeG-v1.127.1.md
@@ -1,0 +1,31 @@
+---
+title: "Pulsar v1.127.1 (Hotfix)"
+author: DeeDeeG
+date: 2025-03-29
+category:
+  - dev
+tag:
+  - release
+---
+
+Pulsar [1.127.1](https://github.com/pulsar-edit/pulsar/releases/tag/v1.127.1) is available now!
+
+<!-- more -->
+
+## Pulsar v1.127.1 (Hotfix)
+
+Here's a quick hotfix release, reverting a change that caused an issue for Linux users.
+
+(For all other changes since v1.126.0, please see the release notes for v1.127.0.)
+
+As always, a huge thank you to our community, contributors, and donations.
+Happy coding, and see you amongst the stars!
+\- The Pulsar Team
+
+---
+
+- Hotfix: Reverted a Wayland-related change that Linux users reported issues with on Electron 12.
+
+### Pulsar
+
+- Revert "Wayland pulsar script" [@mauricioszabo](https://github.com/pulsar-edit/pulsar/pull/1261)

--- a/blog/posts/20250502-DeeDeeG-v1.128.0.md
+++ b/blog/posts/20250502-DeeDeeG-v1.128.0.md
@@ -1,0 +1,41 @@
+---
+title: "Pulsar v1.128.0: May There Be a Spring in Your Step!"
+author: DeeDeeG
+date: 2025-05-02
+category:
+  - dev
+tag:
+  - release
+---
+
+Pulsar [1.128.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.128.0) is available now!
+
+<!-- more -->
+
+## Pulsar v1.128.0: May There Be a Spring in Your Step!
+
+Hello, folks. Another month or so, another Pulsar release!
+
+We've got performance improvements, an improved editing experience for RTL languages, and comment handling for JSON and JSONC files. Please also be aware this month's release contains a security fix, so do update when you can. Thank you to the reporter of this issue.
+
+As always, a huge thank you to our community, contributors, and donations.
+Happy coding, and see you amongst the stars!
+\- The Pulsar Team
+
+---
+
+- Vastly improved support for right-to-left text editing — meaning languages like Arabic, Hebrew, and Farsi.
+- Added support for comments in JSON — both via a new grammar for `.jsonc` files and via a setting to enable comments in regular `.json` files.
+- Fixed performance issues that can arise when reopening a project with existing editor windows.
+- Updated DOMPurify. This is a security fix.
+
+### Pulsar
+
+- Tree-sitter rolling fixes, 1.128 edition [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1251)
+- Cirrus: Pin macOS builds to using Sonoma images [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1280)
+- Bump Ubuntu in CI to `ubuntu-latest` [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1279)
+- Restore ability for packages to focus specs on both Jasmine 1 and Jasmine 2 test runners [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1265)
+- [markdown-preview] Update `dompurify` to 2.5.7 [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1271)
+- Create `SECURITY.md` [@confused-Techie](https://github.com/pulsar-edit/pulsar/pull/1253)
+- Improve support for RTL text input [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1249)
+- [find-and-replace] Fix some bugs in the spec suite [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1221)

--- a/blog/posts/20250630-savetheclocktower-pulsar-next-testing.md
+++ b/blog/posts/20250630-savetheclocktower-pulsar-next-testing.md
@@ -1,0 +1,173 @@
+---
+title: "Pulsar on modern Electron: clearing the runway for arrival"
+author: savetheclocktower
+date: 2025-06-30
+category:
+  - dev
+tag:
+  - modernization
+---
+
+You might’ve noticed that the releases around here have been getting sparser and sparser. We haven’t even had a release since May. Is this the dreaded death spiral?
+
+No, it isn’t; we’ve just entered the cocoon and are preparing to emerge as a more modern and performant butterfly. And you can help us _test_ that butterfly!
+
+<!-- more -->
+
+We’re getting very close to releasing the biggest update to Pulsar that there’s ever been: making it run on a recent version of [Electron](https://www.electronjs.org/), the framework that allows us to write HTML and CSS and JavaScript and turn it into a desktop application. Our current version of Electron is almost four years old, so this is a major upgrade.
+
+When it happens, we think you’ll all notice the difference; for one thing, startup speed should be _much_ faster for everyone. But for some users it might be disruptive, so we’re pre-announcing its arrival so we can set expectations and help folks understand how they might be affected. One way you can guard against this is to [download the new version and help us test it](#help-us-test-pulsarnext)!
+
+But I’m getting ahead of myself. Let’s do this FAQ-style.
+
+## Why haven’t there been regular monthy releases lately?
+
+We’re all volunteers who often have to juggle other things in our lives. Pulsar always shot for a once-a-month release schedule — ideally around the 15th, but often a few days late!
+
+In recent months, however, there simply haven’t been as many things to ship. The most recent version, 1.128.0, was [larger than usual](/blog/20250502-DeeDeeG-v1.128.0.html) — RTL text editing, new highlighting options for comments in JSON, and a couple of big performance improvements. Since then, though, there haven’t even been enough changes to the main Pulsar branch to make a new release a priority.
+
+But why? We certainly haven’t run out of things to address.
+
+I can’t speak for others, but I know the answer for myself: about 80% of my Pulsar-related efforts in this calendar year have been spent on the boring but important goal of Electron modernization.
+
+## Why does Electron need to be updated?
+
+Electron is based on [Chromium](https://www.chromium.org/Home/), the open-source flavor of Google Chrome. Chromium updates on a regular basis for all the reasons that a browser needs to update: new features, architectural improvements, performance improvements to V8 (Chromium’s JavaScript engine, and also the engine that powers Node), and security fixes.
+
+For those reasons, it’s important for Electron to update at a similar cadence to Chromium so that it can also enjoy those features and security fixes.
+
+Electron also bundles [Node](https://nodejs.org/), so each release includes whatever version of Node is stable at time of release. This is important because Electron isn’t very useful if it’s using a version of Node that’s too old to support the requirements of commonly used NPM packages.
+
+## Why is Pulsar’s Electron version so far behind?
+
+Atom literally _invented_ Electron; and, as we learned with Tree-sitter, it’s sometimes expensive to be the first implementer of a major new thing.
+
+[We’ve written before](/blog/20240124-mauricioszabo-the-quest-for-electron-lts.html) about our goal to get Pulsar onto a modern version of Electron. We’re on version **12.2.3** right now — positively _ancient_ considering that the stable version at publish time is **36.4.0**. Version 12.2.3 dates back to November of 2021.
+
+Atom was on an _even older_ version of Electron, and one of the early goals of the Pulsar team was to modernize the editor in all respects, including its Electron version. When it was upgraded to 12.2.3, though, that wasn’t even the newest version of Electron at the time — it was just as far as it could be upgraded without major changes to the codebase.
+
+## What changes had to be made, and why?
+
+One of the biggest tasks on that list — maybe as big as all the others _combined_ — was retiring the original implementation of [Tree-sitter](https://tree-sitter.github.io/tree-sitter/) and replacing it with a modern implementation using WebAssembly. (And if that’s news to you, I have a [seven-part blog post series](/blog/20230925-savetheclocktower-modern-tree-sitter-part-1.html) for your perusal!)
+
+As for the other changes and the _why_: I’d be happy to go into detail in future blog posts, but that’s too big of a topic for this one.
+
+## Why has it taken so long?
+
+The changes we needed to make to Pulsar to upgrade Electron any further have loomed over us since the very beginning of Pulsar, like a list of chores that’s so long that you try to avoid even _looking_ at it.
+
+But you don’t have to look at the whole list at once; you just have to focus on the next task. And if you keep focusing on the next task in the list and _only_ the next task, one day you’ll find yourself with a pretty short list. There used to be dozens of tasks on that list, and now there’s more like _five_. And it feels good.
+
+Now, “slow and steady” is the moral of [_The Tortoise and the Hare_](https://en.wikipedia.org/wiki/The_Tortoise_and_the_Hare), but I’ll bet the bystanders watching that race still got pretty bored! From starting the Tree-sitter modernization project to shipping it as the default, it took almost a year of my free time.
+
+Some of the other tasks have been individually frustrating, but nowhere near as much of a time sink. But the sheer number of them means that we’re 2.5 years into Pulsar’s public existence and only now are we on the verge of delivering this upgrade we’ve known needed to happen since the get-go.
+
+We wish it had happened faster! But it’s happening, and once it’s done we can move onto the next thing.
+
+## What will be different about this new version?
+
+I’ll try to set expectations properly: it’s still going to feel like Pulsar. If you like Pulsar now, you’ll still like it after the Electron update. If there are major aspects of Pulsar you don’t like right now, I can’t imagine any of them will be _substantially_ different after the update.
+
+Except one: the new version of Pulsar **really is quite fast to launch**, and fast to open a new project window. Testers on all platforms have offered this feedback, often without our even telling them that they could expect an improvement in load times. For an editor that has a reputation (whether earned or unearned) of being sluggish, this is a big deal for us; and if that were the only improvement, it’d be plenty on its own.
+
+Apple Silicon users in particular will be _very_ happy to use Pulsar once the upgrade happens, as they are affected by an obscure performance bug that has been plaguing Pulsar since almost the beginning.
+
+But also:
+
+- Newer Electron means newer Node. Electron 12.2.3 runs Node 14; Electron 30.0.9 runs Node 20. [Node 14 has been in “end-of-life” mode for more than two years](https://nodejs.org/en/about/previous-releases#looking-for-the-latest-release-of-a-version-branch), and it’s an ongoing drag on Pulsar development _and_ community package development. If you’re a package author, you might’ve already had situations where you had to use an older version of a dependency just to get it to run correctly in Pulsar.
+
+  I’ve felt this pain, too: [`pulsar-ide-css`](https://web.pulsar-edit.dev/packages/pulsar-ide-css) and [`pulsar-ide-json`](https://web.pulsar-edit.dev/packages/pulsar-ide-json) each run a language server in the background, but neither such server can be run in Node 14. Right now, a user has to configure each package with the path to a `node` binary on their computer so it can run the language servers in a recent version of Node.
+
+  It’s much simpler to have Electron spawn the language server itself using its own built-in version of Node. Once we upgrade Electron, this will once again be possible, and both these packages will become much simpler to use.
+
+- Newer Electron means newer Chromium. The web platform moves fast, and four years’ worth of improvements means things like:
+
+  - The [`:has()` CSS pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/:has) that lets you identify elements by whether they contain other elements.
+  - [Container queries](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries) will be especially nice to have in Pulsar. (For instance: certain pane items can exist either in a narrow side dock or the wide-but-short bottom dock. If they can be styled differently just based on the width of their containing element rather than the viewport, that’s a big deal.)
+  - The [popover API](https://developer.mozilla.org/en-US/docs/Web/API/Popover_API) is something we really should be investigating, too, since we use plenty of modal palettes in Pulsar. It might remove the need to do things like focus management in JavaScript and let them be handled by the browser itself.
+
+These benefits are more immediately compelling to package authors, but users themselves will derive downstream benefits from anything that makes package development easier.
+
+So, in short: you’ll be able to take advantage of performance improvements in Chromium and Electron, and will be able to write and use packages that rely on brand new web platform features.
+
+And, of course, this upgrade wouldn’t be as meaningful if we planned to stay on 30.0.9 indefinitely. We’ve set that release as a fixed target for now, but future Electron upgrades will be much smoother.
+
+## What are the downsides?
+
+There’s only one downside that comes to mind.
+
+Just as Pulsar itself has had to update some of its packages to have them continue to work within Pulsar, **some community packages might need to be updated** in order to be compatible with Pulsar running on newer Electron.
+
+Hardly any packages are affected by this, because it only matters for packages that have native bindings. But those packages tend to do big, important things.
+
+One such example is [`x-terminal-reloaded`](https://web.pulsar-edit.dev/packages/x-terminal-reloaded), the most widely-used terminal package in Pulsar. Luckily, `x-terminal-reloaded` is maintained and has a straightforward upgrade path. We’ve been working hard to make a version of `x-terminal-reloaded` that works identically in both current Pulsar and future Pulsar so that you can upgrade without hassle.
+
+Another example is [`hydrogen`](https://web.pulsar-edit.dev/packages/hydrogen). In that case, the solution is more complicated, since `hydrogen` isn’t maintained anymore. But [@asiloisad](https://github.com/asiloisad)’s got a fork of `hydrogen` called [`hydrogen-next`](https://web.pulsar-edit.dev/packages/hydrogen-next) that uses newer libraries and ought to be a drop-in replacement.
+
+Those are the major packages that are on our radar as needing updates. I’m sure there are others out there, and even if they’re obscure, I’d love to hear about them if they stop working. I’m quite confident we can guide you toward either a fix for the issue or a new package that does the same thing.
+
+But, like I said, **the vast majority of packages will keep working just as they are.** I use about 60 community packages (not including the dozen or more that are under active development at any given time on my computer) and they all run equally well in new Pulsar as current Pulsar.
+
+## When will it be ready?
+
+I speak both truthfully and unhelpfully when I say: it’ll be ready when it’s ready. I do think it’s a matter of months, but it depends on how quickly we can get through the last few chores on the list.
+
+## How can I speed it along?
+
+Several ways. Let me arrange them in order of increasing likelihood:
+
+### Be the exact thing we need right now
+
+If you’re a unicorn that loves Pulsar, has free time to contribute, and knows a lot about C++ and Node bindings… please [reach out to us on Discord](https://discord.gg/7aEbB9dGRT)!
+
+### Contribute according to your expertise
+
+More seriously, even if you don’t have that specific skillset, we can always use more contributors. If you know stuff about the web platform, you’d be useful, even if you don’t have specific experience with Electron. An eagerness to learn and participate is worth far more to us.
+
+We could also use more redundancy on the **devops** side of the project. Pulsar requires a complicated CI workflow for automated testing and automated releases — three platforms, two processor architectures, and at least two “flavors” of release on each OS. If we had at least two people who were familiar enough with the CI flows to troubleshoot any issues that may arise during release, it’d be a lot easier for us to rotate into and out of the project as time permits.
+
+If this sounds like your cup of tea, feel free to jump into the [issue tracker](https://github.com/pulsar-edit/pulsar/issues) or the [list of open pull requests](https://github.com/pulsar-edit/pulsar/pulls)… or else [ask on Discord](https://discord.gg/7aEbB9dGRT) if you’re eager to help but not sure exactly where to start.
+
+### Help us test PulsarNext
+
+But we know even that’s a lot to ask. Lots of you already stare at screens all day for your jobs. But there is another option: if you’re willing to use beta software, you can help us test this new version of Pulsar.
+
+Atom used to have a “nightly” release channel that could be installed alongside the regular version of Atom. In that spirit, we’ve got a “Pulsar on Electron 30” channel that you can install today; it’s called **PulsarNext**.
+
+PulsarNext has been my “daily driver” for months and has been getting easier and easier to use over that time. But we need more beta testers on various platforms so that we can find and fix any remaining issues. The best way you can help us ship this new version of Pulsar is to be a diligent beta tester and file bug reports whenever you encounter bugs.
+
+If this sounds interesting to you, keep reading!
+
+## How do I set up PulsarNext?
+
+1. **Download.** We’ve got rolling releases set up for PulsarNext. [Pick the appropriate release](https://github.com/pulsar-edit/pulsar-electron-next-binaries/releases) for your OS, architecture, and distribution method. But keep in mind that not every “release” has every possible version, since they’re built by different CI jobs. If you don’t see the one you need in a given release, keep looking through older releases until you find one.
+
+2. **Run.** You can launch it from your GUI, as always. But if you launch it from the command line, keep in mind that **its executable name is not `pulsar`; it’s `pulsar-next`**. Likewise, for package tasks, instead of `ppm` you’ll want to use `ppm-next` (or `pulsar-next -p`).
+
+3. **Configure.** For various reasons, PulsarNext does not share a configuration directory with Pulsar. But that means the two can coexist on the same system and can even be running at the same time, should you have a need to do so.
+
+   PulsarNext’s configuration lives in a directory called `~/.pulsar-next` (on macOS and Linux) or `%USERPROFILE%\.pulsar-next` (on Windows).
+
+   To keep packages in sync between the two installations, you’ve got a few options:
+
+   - You can start from scratch and install packages manually.
+   - You can do a one-time copy of your packages from the `packages` sub-folder of your Pulsar home folder to the same path in your PulsarNext home folder.
+   - You can use a package like [sync-settings](https://web.pulsar-edit.dev/packages/sync-settings); it works just as well for this use case as it would for two copies of Pulsar running on two separate machines. Just make sure to configure them with the same Gist ID and access token.
+
+4. **Use and/or test.** Based on feedback, your initial experience with PulsarNext will probably be wholly positive.
+
+   If you do run into any difficulties, please tell us about them. Some examples:
+
+   - We had to rewrite one of our modules that monitors files and directories for changes. If you observe any symptoms that imply that file-watching isn’t working, please let us know. Examples might include the tree view failing to show files after they were created by something outside of PulsarNext, or the editor itself failing to update the contents of a file (when the buffer is unmodified) after an external tool changes the file’s contents.
+   - It should be rare, but if PulsarNext crashes outright, please let us know. (You’ll see a dialog titled “The editor has crashed” and options to close or reload.) On Windows and Linux, crash dumps will be generated within a special `crashdump` folder within your PulsarNext home folder. On macOS, you can find crash reports in Console.app under the “Crash Reports” sidebar heading. Please file an issue against Pulsar, attach your crash report or crash dump, and tell us what you were doing when it happened.
+   - If you’re a Linux user who use a [Wayland](<https://en.wikipedia.org/wiki/Wayland_(protocol)>) display server, please let us know if your keystroke detection isn’t working as expected — especially if you use a keyboard layout other than QWERTY. We had to implement this logic from scratch for Wayland users so that it worked just as well as it does for [X](https://en.wikipedia.org/wiki/X_Window_System) users. Feedback so far has been positive, but we’d love to get more data points.
+
+   If you encounter bugs, you can [file them as issues](https://github.com/pulsar-edit/pulsar/issues), or [drop into Discord](https://discord.gg/7aEbB9dGRT) if you want to make sure what you’re seeing isn’t intended.
+
+## More to come
+
+There’s a piece of advice I’ve sometimes heard: if you want to make sure you follow through with something, tell your friends you’re going to do it. It’s based on psychology; people don’t like to break commitments that they’ve made publicly.
+
+Hence the purpose of this post isn’t just to ask for help; it’s to demonstrate a commitment to following through. We want to deliver this great upgrade as soon as we can, so we’re telling our friends about it — all of you, our loyal community of users.
+
+As always, we’re grateful to you for your support — but especially for your patience through this long journey. Happy coding!

--- a/blog/posts/20250807-DeeDeeG-v1.129.0.md
+++ b/blog/posts/20250807-DeeDeeG-v1.129.0.md
@@ -1,0 +1,45 @@
+---
+title: "Pulsar v1.129.0: An August Occasion"
+author: DeeDeeG
+date: 2025-08-07
+category:
+  - dev
+tag:
+  - release
+---
+
+Pulsar [1.129.0](https://github.com/pulsar-edit/pulsar/releases/tag/v1.129.0) is available now!
+
+<!-- more -->
+
+## Pulsar v1.129.0: An _August_ Occasion
+
+Howdy folks,
+
+Another fine Pulsar release, Pulsar 1.129.0, is available for your use and enjoyment. See changelog below for details.
+
+A big shout-out to @Drsheppard01 for their first contribution in the form of PR [#1241](https://github.com/pulsar-edit/pulsar/pull/1241), and to @jmanuel1 for the issue report [#1302](https://github.com/pulsar-edit/pulsar/issues/1302) that led to a quick fix from @savetheclocktower in PR [#1303](https://github.com/pulsar-edit/pulsar/pull/1303). And to several members of the community who have given feedback on GitHub, Discord, etc.
+
+As always, a huge thank you to our community, contributors, and donations.
+Happy coding, and see you amongst the stars!
+\- The Pulsar Team
+
+---
+
+## 1.129.0
+
+- Some minor Tree-sitter fixes, including fixing a bug in SCSS highlighting and ensuring proper highlighting support for abstract methods in TypeScript.
+- When viewing a file that exists on disk outside of your project root, you may now use **Tree View: Rename** to “import” it into your project folder by giving it a relative path.
+- Updated various dependencies for security reasons.
+- Updated AppImages to type 2 runtime -- `libfuse` is no-longer required to be installed on the end-user's system to use Pulsar's AppImages!
+
+### Pulsar
+
+- Cirrus: Fetch Buster packages from archive.debian.org [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1315)
+- Update deps June 2025 [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1294)
+- Update appimagetool link in ./scripts/fix-linux-appimage.sh [@ Drsheppard01](https://github.com/pulsar-edit/pulsar/pull/1241)
+- Tree-sitter rolling fixes, 1.129 edition [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1300)
+- Fix CI build job in Ubuntu [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1309)
+- [tree-view] Allow `tree-view:rename` to "import" the current file… [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1303)
+- Cirrus: Update Rolling upload token [@DeeDeeG](https://github.com/pulsar-edit/pulsar/pull/1292)
+- Refactor `StateStore` to remove dependency on the `atom` global [@savetheclocktower](https://github.com/pulsar-edit/pulsar/pull/1256)

--- a/layouts/page-footer.ejs
+++ b/layouts/page-footer.ejs
@@ -1,0 +1,37 @@
+<footer class="page-footer">
+  <div class="page-footer__content">
+    <div class="page-footer__sections">
+      <section class="page-footer__section">
+        <header class="page-footer__section-title">Pulsar</header>
+        <ul class="page-footer__links">
+          <li><a href="/download">Downloads</a></li>
+          <li><a href="https://docs.pulsar-edit.dev/">Documentation</a></li>
+          <li><a href="https://web.pulsar-edit.dev/">Package repository</a></li>
+        </ul>
+      </section>
+
+      <section class="page-footer__section">
+        <header class="page-footer__section-title">Team</header>
+        <ul class="page-footer__links">
+          <li><a href="https://blog.pulsar-edit.dev/">Blog</a></li>
+          <li><a href="/about">About us</a></li>
+          <li><a href="https://github.com/pulsar-edit">Org repositories</a></li>
+        </ul>
+      </section>
+
+      <section class="page-footer__section">
+        <header class="page-footer__section-title">Resources</header>
+        <ul class="page-footer__links">
+          <li><a href="/privacy">Privacy policy</a></li>
+          <li><a href="/code-of-conduct">Code of conduct</a></li>
+          <li><a href="/community">Contact us</a></li>
+        </ul>
+      </section>
+    </div>
+
+    <div class="page-footer__copyright">
+      <% let currentYear = new Date().getFullYear(); %>
+      Pulsar-Edit &copy; 2022–<%= currentYear %>
+    </div>
+  </div>
+</footer>

--- a/less/mixins.less
+++ b/less/mixins.less
@@ -1,0 +1,7 @@
+.top-level-element() {
+  box-sizing: border-box;
+  padding-left: var(--content-margin);
+  padding-right: var(--content-margin);
+  max-width: var(--content-max-width);
+  margin: 0 auto;
+}

--- a/less/page-footer.less
+++ b/less/page-footer.less
@@ -1,0 +1,69 @@
+.page-footer {
+  margin: 0 0 3rem;
+
+  &__content {
+    .top-level-element();
+  }
+
+  &__sections {
+    border-top: 1px solid var(--thematic-break-color);
+    padding-top: 3rem;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-items: center;
+  }
+
+  &__section {
+    flex-basis: 100%;
+    font-size: 14px;
+    margin: 0 0 3rem;
+    max-width: 50vw;
+    min-width: 200px;
+  }
+
+  &__section-title {
+    font-size: 20px;
+    font-weight: 700;
+    margin: 0 0 1rem;
+  }
+
+  &__links {
+    list-style-type: none;
+    margin: 0;
+    padding: 0;
+
+    li {
+      margin: 0;
+      padding: 0;
+    }
+
+    li a {
+      font-weight: 500;
+      display: inline-block;
+      line-height: 1.7;
+      margin-bottom: 2px;
+    }
+  }
+
+  &__copyright {
+    font-size: 14px;
+    margin-top: 3rem;
+    padding-top: 3rem;
+    border-top: 1px solid var(--thematic-break-color);
+    text-align: center;
+  }
+}
+
+@media (min-width: 750px) {
+  .page-footer {
+    &__sections {
+      flex-direction: row;
+    }
+
+    &__section {
+      margin: 0 5rem;
+      min-width: 0;
+    }
+  }
+}

--- a/less/tags.less
+++ b/less/tags.less
@@ -1,0 +1,68 @@
+@tag-color-1:  hsl(0,   57%, 71%);
+@tag-color-2:  hsl(30,  57%, 71%);
+@tag-color-3:  hsl(60,  57%, 71%);
+@tag-color-4:  hsl(90,  57%, 71%);
+@tag-color-5:  hsl(120, 57%, 71%);
+@tag-color-6:  hsl(150, 57%, 71%);
+@tag-color-7:  hsl(180, 57%, 71%);
+@tag-color-8:  hsl(210, 57%, 71%);
+@tag-color-9:  hsl(240, 57%, 71%);
+@tag-color-10: hsl(270, 57%, 71%);
+@tag-color-11: hsl(300, 57%, 71%);
+@tag-color-12: hsl(330, 57%, 71%);
+
+.tag-loop(@counter) when (@counter > 0) {
+  .tag-loop((@counter - 1));    // next iteration
+  .tag--variant-@{counter} {
+    @tag-text-color: darken(@@tag-color-var, 60%);
+    --tag-shadow-color: lighten(@tag-text-color, 40%);
+    @tag-color-var: "tag-color-@{counter}";
+    @tag-bg-color: @@tag-color-var;
+    color: @tag-text-color;
+    background-color: @tag-bg-color;
+
+    &:hover {
+      color: @tag-text-color;
+    }
+  }
+}
+
+:root {
+  // Tags
+  --tag-color-1:  @tag-color-1;
+  --tag-color-2:  @tag-color-2;
+  --tag-color-3:  @tag-color-3;
+  --tag-color-4:  @tag-color-4;
+  --tag-color-5:  @tag-color-5;
+  --tag-color-6:  @tag-color-6;
+  --tag-color-7:  @tag-color-7;
+  --tag-color-8:  @tag-color-8;
+  --tag-color-9:  @tag-color-9;
+  --tag-color-10: @tag-color-10;
+  --tag-color-11: @tag-color-11;
+  --tag-color-12: @tag-color-12;
+}
+
+.category,
+.tag {
+  padding: 1px 3px;
+  border-radius: 2px;
+  font-size: 90%;
+
+  &:hover {
+    color: inherit;
+    text-decoration: none;
+  }
+}
+
+.tag-loop(12);
+
+.tag {
+  font-weight: 500;
+  transition-property: color, background-color, outline-color, border-color, text-shadow;
+  transition-duration: 0.2s;
+
+  &:hover {
+    text-decoration: none;
+  }
+}

--- a/less/time.less
+++ b/less/time.less
@@ -1,0 +1,29 @@
+@media screen and (max-width: 549px) {
+  .formatted-date {
+    &:not(.formatted-date--short) {
+      display: none;
+    }
+  }
+}
+
+@media screen and (min-width: 550px) {
+  .formatted-date {
+    &.formatted-date--medium {
+      display: inline;
+    }
+    &:not(.formatted-date--medium) {
+      display: none;
+    }
+  }
+}
+
+@media screen and (min-width: 750px) {
+  .formatted-date {
+    &.formatted-date--long {
+      display: inline;
+    }
+    &:not(.formatted-date--long) {
+      display: none;
+    }
+  }
+}


### PR DESCRIPTION
These should be all the blog posts that have been added since we started working on the blog redesign. Also fixed a typo in an older post.

As usual, slap the green button when this satisfies you, since there are no green buttons on this side of the table.