### PR TITLE
Prevent double-escaping of HTML in the titles of lists of posts

### DIFF
--- a/layouts/blocks.ejs
+++ b/layouts/blocks.ejs
@@ -3,7 +3,7 @@
   <% for (const node of blocks) { %>
   <section class="block">
     <header class="block__header">
-      <a href="<%= node.page.url %>"><%= helpers.markdownInline(node.data.title) %></a>
+      <a href="<%= node.page.url %>"><%- helpers.markdownInline(node.data.title) %></a>
     </header>
     <div class="block__summary">
       <%- helpers.findPostSummary(node.content) -%>


### PR DESCRIPTION
Noticed this problem in a post title:

<p><img width="585" height="142" alt="Screenshot 2026-05-17 at 7 37 31 PM" src="https://github.com/user-attachments/assets/b0543633-4bb2-4dc0-98be-0b340eb75497" /></p>

This happens because we were inadvertently double-escaping the ampersand in this post title. Since the `markdownInline` helper already does the work of encoding the ampersand, we should use `<%-` rather than `<%=` so that it isn't further encoded.
