### PR TITLE
Remove `WIP` from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Pulsar Blog (WIP)
+# Pulsar Blog
 
 This repo contains the website source code for `https://blog.pulsar-edit.dev`.
 


### PR DESCRIPTION
Rather simple PR, but just a small update to the readme of this repo that is no longer accurate.